### PR TITLE
Note use of universal equals and hashcode in Dist

### DIFF
--- a/kernel-testkit/src/main/scala/schrodinger/kernel/testkit/Dist.scala
+++ b/kernel-testkit/src/main/scala/schrodinger/kernel/testkit/Dist.scala
@@ -33,6 +33,11 @@ import cats.kernel.instances.MapMonoid
 import cats.syntax.all.*
 import schrodinger.math.syntax.*
 
+/**
+ * @note
+ *   The implementation relies on universal equals and hashCode of `A` for performance. Results
+ *   will be incorrect otherwise.
+ */
 final case class Dist[P, A](support: Map[A, P]):
 
   def map[B](f: A => B)(using P: AdditiveMonoid[P]): Dist[P, B] =


### PR DESCRIPTION
Closes https://github.com/armanbilge/schrodinger/issues/155, although this is effectively a wontfix.

As of https://github.com/armanbilge/schrodinger/pull/161 `Dist` lives in the testkit. Since it is intended only for testing purposes, I think this is a very reasonable compromise. The real fix would significantly compromise performance; meanwhile, requiring that use be restricted to types whose universal equals and hashcode are implemented correctly seems innocuous enough for testing purposes.

Btw, this article was excellent reading: https://okmij.org/ftp/Haskell/set-monad.html