### PR TITLE
Rework `tailRecM` for `Dist`

### DIFF
--- a/kernel-testkit/src/main/scala/schrodinger/kernel/testkit/Dist.scala
+++ b/kernel-testkit/src/main/scala/schrodinger/kernel/testkit/Dist.scala
@@ -21,7 +21,6 @@ import algebra.ring.AdditiveMonoid
 import algebra.ring.CommutativeRig
 import algebra.ring.MultiplicativeMonoid
 import algebra.ring.Rig
-import algebra.ring.Semifield
 import cats.CommutativeMonad
 import cats.Eq
 import cats.Foldable
@@ -32,7 +31,6 @@ import cats.kernel.Hash
 import cats.kernel.Semigroup
 import cats.kernel.instances.MapMonoid
 import cats.syntax.all.*
-import schrodinger.math.Monus
 import schrodinger.math.syntax.*
 
 /**
@@ -118,47 +116,3 @@ object Dist:
       using Categorical[Map[A, P], A][Dist[P, *]]): Categorical[G[(A, P)], A][Dist[P, *]] =
     case Categorical.Params(support) =>
       Categorical(support.toIterable.toMap)
-
-  import scala.collection.mutable
-
-  private trait RowReducible[A]:
-    def swap(i: Int, j: Int): Unit
-    def scale(i: Int, a: A): Unit
-    def add(i: Int, a: A, j: Int): Unit
-    def monus(i: Int, a: A, j: Int): Unit
-
-  private class Matrix[A: Semifield: Monus](data: mutable.ArraySeq[mutable.ArraySeq[A]])
-      extends RowReducible[A]:
-    def apply(i: Int, j: Int): A = data(i)(j)
-
-    def swap(i: Int, j: Int): Unit =
-      val (x, y) = (data(i), data(j))
-      data(j) = x
-      data(i) = y
-
-    def scale(i: Int, a: A): Unit =
-      data(i).mapInPlace(_ * a)
-
-    def add(i: Int, a: A, j: Int): Unit =
-      data(j).indices.foreach(k => data(j)(k) += a * data(i)(k))
-
-    def monus(i: Int, a: A, j: Int): Unit =
-      data(j).indices.foreach(k => data(j)(k) ∸= a * data(i)(k))
-
-  private class Augmented[A](left: RowReducible[A], right: RowReducible[A])
-      extends RowReducible[A]:
-    def swap(i: Int, j: Int): Unit =
-      left.swap(i, j)
-      right.swap(i, j)
-
-    def scale(i: Int, a: A): Unit =
-      left.scale(i, a)
-      right.scale(i, a)
-
-    def add(i: Int, a: A, j: Int): Unit =
-      left.add(i, a, j)
-      right.add(i, a, j)
-
-    def monus(i: Int, a: A, j: Int): Unit =
-      left.monus(i, a, j)
-      right.monus(i, a, j)

--- a/kernel-testkit/src/main/scala/schrodinger/kernel/testkit/Dist.scala
+++ b/kernel-testkit/src/main/scala/schrodinger/kernel/testkit/Dist.scala
@@ -33,6 +33,8 @@ import cats.kernel.instances.MapMonoid
 import cats.syntax.all.*
 import schrodinger.math.syntax.*
 
+import scala.util.NotGiven
+
 /**
  * @note
  *   The implementation relies on universal equals and hashCode of `A` for performance. Results
@@ -59,16 +61,14 @@ object Dist:
   def pure[P, A](a: A)(using P: MultiplicativeMonoid[P]): Dist[P, A] =
     Dist(Map(a -> P.one))
 
-  def monad[P: Rig](n: Int): Monad[Dist[P, *]] = DistMonad(n)
+  given [P: Rig: Eq](using NotGiven[CommutativeRig[P]]): Monad[Dist[P, *]] = DistMonad[P]
 
-  def commutativeMonad[P: CommutativeRig](n: Int): CommutativeMonad[Dist[P, *]] =
-    new DistMonad(n) with CommutativeMonad[Dist[P, *]]
+  given [P: CommutativeRig: Eq]: CommutativeMonad[Dist[P, *]] =
+    new DistMonad[P] with CommutativeMonad[Dist[P, *]]
 
   given [P: Eq, A: Eq]: Eq[Dist[P, A]] = Eq.by(_.support)
 
-  private class DistMonad[P](n: Int)(using P: Rig[P]) extends Monad[Dist[P, *]]:
-    private given Semigroup[P] = P.additive
-
+  private class DistMonad[P: Eq](using P: Rig[P]) extends Monad[Dist[P, *]]:
     def pure[A](a: A): Dist[P, A] = Dist.pure(a)(using P)
 
     override def map[A, B](da: Dist[P, A])(f: A => B): Dist[P, B] = da.map(f)
@@ -76,17 +76,17 @@ object Dist:
     def flatMap[A, B](da: Dist[P, A])(f: A => Dist[P, B]): Dist[P, B] = da.flatMap(f)
 
     def tailRecM[A, B](a: A)(f: A => Dist[P, Either[A, B]]): Dist[P, B] =
-      var fa = f(a)
-      var db = Map.empty[B, P]
-      var i = 0
-      while i < n do
-        val as = fa.support.collect { case (Left(a), p) => a -> p }
-        val bs = fa.support.collect { case (Right(b), p) => b -> p }
-        db = db |+| bs
-        if db.nonEmpty then i += 1 // don't start counter until we've hit some b
-        if as.nonEmpty then fa = Dist(as).flatMap(f)
-        else i = n
-      Dist(db)
+      given Semigroup[P] = P.additive
+
+      def go(da: Dist[P, Either[A, B]], db: Map[B, P]): Dist[P, B] =
+        val as = da.support.collect { case (Left(a), p) => a -> p }
+        val bs = da.support.collect { case (Right(b), p) => b -> p }
+        val dbp = db |+| bs
+        if P.isZero(P.sum(da.support.view.filterKeys(_.isLeft).values)) then
+          Dist(dbp)
+        else go(Dist(as).flatMap(f), dbp)
+      
+      go(f(a), Map.empty)
 
   given [P](
       using density: Bernoulli[P, Boolean][Density[Id, P]]): Bernoulli[P, Boolean][Dist[P, *]] =

--- a/kernel-testkit/src/test/scala/schrodinger/kernel/testkit/DistSpec.scala
+++ b/kernel-testkit/src/test/scala/schrodinger/kernel/testkit/DistSpec.scala
@@ -18,13 +18,13 @@ package schrodinger.kernel.testkit
 
 import algebra.instances.all.*
 import cats.CommutativeMonad
+import cats.kernel.laws.discipline.EqTests
 import cats.laws.discipline.CommutativeMonadTests
 import org.scalacheck.Arbitrary
 import org.scalacheck.Cogen
 import org.scalacheck.Gen
 import org.specs2.mutable.Specification
 import org.typelevel.discipline.specs2.mutable.Discipline
-import cats.kernel.laws.discipline.EqTests
 
 class DistSpec extends Specification, Discipline:
 

--- a/kernel-testkit/src/test/scala/schrodinger/kernel/testkit/DistSpec.scala
+++ b/kernel-testkit/src/test/scala/schrodinger/kernel/testkit/DistSpec.scala
@@ -24,6 +24,7 @@ import org.scalacheck.Cogen
 import org.scalacheck.Gen
 import org.specs2.mutable.Specification
 import org.typelevel.discipline.specs2.mutable.Discipline
+import cats.kernel.laws.discipline.EqTests
 
 class DistSpec extends Specification, Discipline:
 
@@ -37,7 +38,12 @@ class DistSpec extends Specification, Discipline:
         .map(_.toMap)
         .map(Dist(_)))
 
+  given [A](using cogen: Cogen[Map[A, Int]]): Cogen[Dist[Int, A]] =
+    cogen.contramap(_.support)
+
   checkAll(
     "Dist",
     CommutativeMonadTests[Dist[Int, _]].commutativeMonad[Byte, Byte, Byte]
   )
+
+  checkAll("Dist", EqTests[Dist[Int, Byte]].eqv)

--- a/kernel-testkit/src/test/scala/schrodinger/kernel/testkit/DistSpec.scala
+++ b/kernel-testkit/src/test/scala/schrodinger/kernel/testkit/DistSpec.scala
@@ -37,8 +37,6 @@ class DistSpec extends Specification, Discipline:
         .map(_.toMap)
         .map(Dist(_)))
 
-  given CommutativeMonad[Dist[Int, *]] = Dist.commutativeMonad[Int](1024)
-
   checkAll(
     "Dist",
     CommutativeMonadTests[Dist[Int, _]].commutativeMonad[Byte, Byte, Byte]


### PR DESCRIPTION
It is now non-terminating for any `tailRecM` for which there is no upper bound on the number of steps e.g. an algorithm that flips a fair coin to decide to terminate or recurse. I think this is a reasonable compromise and is better than the previous ad-hoc finite-step approximation. It also means we can put instances into scope.

I briefly considered an idea to analytically calculate the [absorbing probabilities](https://en.wikipedia.org/wiki/Absorbing_Markov_chain#Absorbing_probabilities). It would be really cool, and is theoretically feasible, but annoying to implement and impractical to use.