### PR TITLE
Make `LogDouble` constants `final val`s

### DIFF
--- a/math/src/main/scala/schrodinger/math/LogDouble.scala
+++ b/math/src/main/scala/schrodinger/math/LogDouble.scala
@@ -23,13 +23,13 @@ import cats.kernel.Order
 opaque type LogDouble = Double
 
 object LogDouble:
-  val Zero: LogDouble = Double.NegativeInfinity
-  val One: LogDouble = 0.0
-  val Two: LogDouble = 0.6931471805599453
-  val MinPositiveValue: LogDouble = Double.MinValue
-  val MaxValue: LogDouble = Double.MaxValue
-  val PositiveInfinity: LogDouble = Double.PositiveInfinity
-  val NaN: LogDouble = Double.NaN
+  final val Zero: LogDouble = Double.NegativeInfinity
+  final val One: LogDouble = 0.0
+  final val Two: LogDouble = 0.6931471805599453
+  final val MinPositiveValue: LogDouble = Double.MinValue
+  final val MaxValue: LogDouble = Double.MaxValue
+  final val PositiveInfinity: LogDouble = Double.PositiveInfinity
+  final val NaN: LogDouble = Double.NaN
 
   inline def apply(x: Double): LogDouble = Math.log(x)
   inline def exp(x: Double): LogDouble = x

--- a/math/src/main/scala/schrodinger/math/LogDouble.scala
+++ b/math/src/main/scala/schrodinger/math/LogDouble.scala
@@ -26,7 +26,7 @@ object LogDouble:
   final val Zero: LogDouble = Double.NegativeInfinity
   final val One: LogDouble = 0.0
   final val Two: LogDouble = 0.6931471805599453
-  final val MinPositiveValue: LogDouble = Double.MinValue
+  final val MinPositiveValue: LogDouble = -Double.MaxValue
   final val MaxValue: LogDouble = Double.MaxValue
   final val PositiveInfinity: LogDouble = Double.PositiveInfinity
   final val NaN: LogDouble = Double.NaN


### PR DESCRIPTION
Now they can be constant-folded. Apparently this is guaranteed by the Scala spec, here maybe?
https://www.scala-lang.org/files/archive/spec/2.13/04-basic-declarations-and-definitions.html#value-declarations-and-definitions