### PR TITLE
Introduce `Logarithmic`

### DIFF
--- a/laws/src/main/scala/schrodinger/laws/LogarithmicLaws.scala
+++ b/laws/src/main/scala/schrodinger/laws/LogarithmicLaws.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package schrodinger.laws
+
+import schrodinger.math.Logarithmic
+import cats.kernel.laws.*
+
+trait LogarithmicLaws[A, L](using val L: Logarithmic[A, L]):
+
+  def logarithmRoundTrip(a: A): IsEq[A] =
+    L.exponential(L.logarithm(a)) <-> a
+
+  def exponentialRoundTrip(l: L): IsEq[L] =
+    L.logarithm(L.exponential(l)) <-> l
+
+  def oneIsZero: IsEq[A] =
+    L.exponential(L.semifield.one) <-> L.divisionRing.zero
+
+  def timesIsPlus(x: L, y: L): IsEq[A] =
+    L.exponential(L.semifield.times(x, y)) <->
+      L.divisionRing.plus(L.exponential(x), L.exponential(y))
+
+  def divIsMinus(x: L, y: L): IsEq[A] =
+    L.exponential(L.semifield.div(x, y)) <->
+      L.divisionRing.minus(L.exponential(x), L.exponential(y))
+
+object LogarithmicLaws:
+  def apply[A, L](using Logarithmic[A, L]): LogarithmicLaws[A, L] = new {}
+  

--- a/laws/src/main/scala/schrodinger/laws/LogarithmicLaws.scala
+++ b/laws/src/main/scala/schrodinger/laws/LogarithmicLaws.scala
@@ -40,4 +40,3 @@ trait LogarithmicLaws[A, L](using val L: Logarithmic[A, L]):
 
 object LogarithmicLaws:
   def apply[A, L](using Logarithmic[A, L]): LogarithmicLaws[A, L] = new {}
-  

--- a/laws/src/main/scala/schrodinger/laws/LogarithmicTests.scala
+++ b/laws/src/main/scala/schrodinger/laws/LogarithmicTests.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package schrodinger.laws
+
+import cats.kernel.Eq
+import cats.kernel.laws.discipline.*
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop
+import org.scalacheck.Prop.forAll
+import org.typelevel.discipline.Laws
+import schrodinger.math.Logarithmic
+
+trait LogarithmicTests[A, L](laws: LogarithmicLaws[A, L]) extends Laws:
+
+  def logarithmic(using Arbitrary[A], Arbitrary[L], Eq[A], Eq[L]): RuleSet =
+    val props = Seq[(String, Prop)](
+      "logarithm round trip" -> forAll(laws.logarithmRoundTrip(_)),
+      "exponential round trip" -> forAll(laws.exponentialRoundTrip(_)),
+      "one is zero" -> laws.oneIsZero,
+      "times is plus" -> forAll(laws.timesIsPlus(_, _)),
+      "div is minus" -> forAll(laws.divIsMinus(_, _)),
+    )
+
+    DefaultRuleSet("logarithmic", None, props*)
+
+object LogarithmicTests:
+
+  def apply[A, L](using Logarithmic[A, L]): LogarithmicTests[A, L] =
+    new LogarithmicTests(LogarithmicLaws[A, L]) {}

--- a/math/shared/src/main/scala/schrodinger/math/Logarithmic.scala
+++ b/math/shared/src/main/scala/schrodinger/math/Logarithmic.scala
@@ -21,8 +21,7 @@ import algebra.ring.DivisionRing
 import algebra.ring.Field
 import algebra.ring.Semifield
 
-trait Logarithmic[A]:
-  type L
+trait Logarithmic[A, L]:
 
   def semifield: Semifield[L]
 
@@ -36,7 +35,7 @@ trait Logarithmic[A]:
 
   extension (a: A) inline def toLogarithm: L = logarithm(a)
 
-trait CommutativeLogarithmic[A] extends Logarithmic[A]:
+trait CommutativeLogarithmic[A, L] extends Logarithmic[A, L]:
   def commutativeSemifield: CommutativeSemifield[L]
 
   final def semifield = commutativeSemifield
@@ -45,18 +44,11 @@ trait CommutativeLogarithmic[A] extends Logarithmic[A]:
 
   final def divisionRing = field
 
-object CommutativeLogarithmic:
-  type Aux[A, L0] = CommutativeLogarithmic[A] { type L = L0 }
-
 object Logarithmic:
 
-  type Aux[A, L0] = Logarithmic[A] { type L = L0 }
+  inline def apply[A, L](using l: Logarithmic[A, L]): l.type = l
 
-  inline def apply[A](using l: Logarithmic[A]): l.type = l
-
-  given CommutativeLogarithmic.Aux[Double, LogDouble] = new CommutativeLogarithmic[Double]:
-    type L = LogDouble
-
+  given CommutativeLogarithmic[Double, LogDouble] with
     def commutativeSemifield =
       LogDouble.given_CommutativeSemifield_LogDouble_Monus_LogDouble_Order_LogDouble_Hash_LogDouble
 
@@ -64,4 +56,4 @@ object Logarithmic:
 
     val exponential = (_: LogDouble).log
 
-    val logarithm = LogDouble(_)
+    val logarithm = LogDouble.exp(_)

--- a/math/shared/src/main/scala/schrodinger/math/Logarithmic.scala
+++ b/math/shared/src/main/scala/schrodinger/math/Logarithmic.scala
@@ -16,6 +16,7 @@
 
 package schrodinger.math
 
+import algebra.instances.all.*
 import algebra.ring.CommutativeSemifield
 import algebra.ring.DivisionRing
 import algebra.ring.Field
@@ -49,10 +50,9 @@ object Logarithmic:
   inline def apply[A, L](using l: Logarithmic[A, L]): l.type = l
 
   given CommutativeLogarithmic[Double, LogDouble] with
-    def commutativeSemifield =
-      LogDouble.given_CommutativeSemifield_LogDouble_Monus_LogDouble_Order_LogDouble_Hash_LogDouble
+    def commutativeSemifield = summon
 
-    def field = algebra.instances.all.doubleAlgebra
+    def field = summon
 
     def exponential(l: LogDouble) = l.log
 

--- a/math/shared/src/main/scala/schrodinger/math/Logarithmic.scala
+++ b/math/shared/src/main/scala/schrodinger/math/Logarithmic.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package schrodinger.math
+
+import algebra.ring.CommutativeSemifield
+import algebra.ring.DivisionRing
+import algebra.ring.Field
+import algebra.ring.Semifield
+
+trait Logarithmic[A]:
+  type L
+
+  def semifield: Semifield[L]
+
+  def divisionRing: DivisionRing[A]
+
+  def exponential: L => A
+
+  def logarithm: A => L
+
+  extension (l: L) inline def toExponential: A = exponential(l)
+
+  extension (a: A) inline def toLogarithm: L = logarithm(a)
+
+trait CommutativeLogarithmic[A] extends Logarithmic[A]:
+  def commutativeSemifield: CommutativeSemifield[L]
+
+  final def semifield = commutativeSemifield
+
+  def field: Field[A]
+
+  final def divisionRing = field
+
+object CommutativeLogarithmic:
+  type Aux[A, L0] = CommutativeLogarithmic[A] { type L = L0 }
+
+object Logarithmic:
+
+  type Aux[A, L0] = Logarithmic[A] { type L = L0 }
+
+  inline def apply[A](using l: Logarithmic[A]): l.type = l
+
+  given CommutativeLogarithmic.Aux[Double, LogDouble] = new CommutativeLogarithmic[Double]:
+    type L = LogDouble
+
+    def commutativeSemifield =
+      LogDouble.given_CommutativeSemifield_LogDouble_Monus_LogDouble_Order_LogDouble_Hash_LogDouble
+
+    def field = algebra.instances.all.doubleAlgebra
+
+    val exponential = (_: LogDouble).log
+
+    val logarithm = LogDouble(_)

--- a/math/shared/src/main/scala/schrodinger/math/Logarithmic.scala
+++ b/math/shared/src/main/scala/schrodinger/math/Logarithmic.scala
@@ -27,9 +27,9 @@ trait Logarithmic[A, L]:
 
   def divisionRing: DivisionRing[A]
 
-  def exponential: L => A
+  def exponential(l: L): A
 
-  def logarithm: A => L
+  def logarithm(a: A): L
 
   extension (l: L) inline def toExponential: A = exponential(l)
 
@@ -54,6 +54,6 @@ object Logarithmic:
 
     def field = algebra.instances.all.doubleAlgebra
 
-    val exponential = (_: LogDouble).log
+    def exponential(l: LogDouble) = l.log
 
-    val logarithm = LogDouble.exp(_)
+    def logarithm(a: Double) = LogDouble.exp(a)

--- a/tests/shared/src/test/scala/schrodinger/math/LogDoubleSuite.scala
+++ b/tests/shared/src/test/scala/schrodinger/math/LogDoubleSuite.scala
@@ -27,6 +27,7 @@ import org.scalacheck.Arbitrary
 import org.scalacheck.Cogen
 import org.scalacheck.Gen
 import org.scalacheck.Prop.*
+import schrodinger.laws.LogarithmicTests
 import schrodinger.laws.MonusTests
 
 class LogDoubleSuite extends DisciplineSuite:
@@ -74,3 +75,5 @@ class LogDoubleSuite extends DisciplineSuite:
   checkAll("LogDouble", OrderTests[LogDouble].order)
   checkAll("LogDouble", HashTests[LogDouble].hash)
   checkAll("LogDoubleAlgebra", SerializableTests.serializable(CommutativeSemifield[LogDouble]))
+
+  checkAll("LogDouble", LogarithmicTests[Double, LogDouble].logarithmic)


### PR DESCRIPTION
Inspired by `cats.Parallel`, for modeling e.g. the relationship between `Double` and `LogDouble`. They are the same datatype, with two different algebras.

Practically, this helps to interface between probability-native APIs (where `LogDouble` is an ideal representation) and "numerical" APIs (typically inference algorithms, which may be in terms of e.g. potential energy). 